### PR TITLE
1014774 JavaVersion check

### DIFF
--- a/jloadr-bootstrap/pom.xml
+++ b/jloadr-bootstrap/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>jloadr-bootstrap</artifactId>
-  <version>1.0.11</version>
+  <version>1.0.12</version>
   <packaging>multi-release-jar</packaging>
 
   <dependencies>

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/ShowErrorUtil.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/ShowErrorUtil.java
@@ -36,6 +36,22 @@ public class ShowErrorUtil
 
   }
 
+  public static void showStartError(String pSimpleMsg)
+  {
+    String title = UIManager.getString("OptionPane.messageDialogTitle");
+    JTextArea textArea = new JTextArea(pSimpleMsg);
+    textArea.setEditable(false);
+    textArea.setOpaque(false);
+    textArea.setLineWrap(true);
+    textArea.setWrapStyleWord(true);
+
+    JScrollPane scrollPane = new JScrollPane(textArea);
+    scrollPane.setBorder(null);
+    scrollPane.setPreferredSize(new Dimension(300, 50));
+
+    JOptionPane.showMessageDialog(null, scrollPane, title, JOptionPane.WARNING_MESSAGE);
+  }
+
   /**
    * Shows a dialog with a small error message as simple as possible
    */

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
@@ -20,6 +20,11 @@ public class Starter
     if (args.length == 0)
       throw new RuntimeException("first parameter must be the repository url");
 
+    String minimalVersion = System.getProperty("min.java");
+    if(!(VersionUtil.validateJavaVersion(System.getProperty("java.version"), minimalVersion)))
+      throw new RuntimeException("Your Java is outdated, please use at least Java " +
+          (minimalVersion == null ? VersionUtil.getDefaultVersion() : minimalVersion));
+
     _initTrustManager();
 
     String useSystemProxies = System.getProperty("java.net.useSystemProxies");
@@ -29,11 +34,6 @@ public class Starter
     Throwable loadError = null;
     try
     {
-      String minimalVersion = System.getProperty("min.java");
-      if(!(VersionUtil.validateJavaVersion(System.getProperty("java.version"), minimalVersion)))
-        throw new RuntimeException("Your Java is outdated, please use at least Java " +
-            (minimalVersion == null ? VersionUtil.getDefaultVersion() : minimalVersion));
-
       URL url = BootstrapUtil.getMoved(new URL(args[0]));
       _loadNewVersion(url);
       args[0] = url.toExternalForm();

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
@@ -22,8 +22,12 @@ public class Starter
 
     String minimalVersion = System.getProperty("min.java");
     if(!(VersionUtil.validateJavaVersion(System.getProperty("java.version"), minimalVersion)))
-      throw new RuntimeException("Your Java is outdated, please use at least Java " +
-          (minimalVersion == null ? VersionUtil.getDefaultVersion() : minimalVersion));
+    {
+      String msg = "Your Java is outdated, please use at least Java " +
+          (minimalVersion == null ? VersionUtil.getDefaultVersion() : minimalVersion);
+      ShowErrorUtil.showStartError(msg);
+      throw new RuntimeException(msg);
+    }
 
     _initTrustManager();
 

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
@@ -14,6 +14,9 @@ public class Starter
   private static final String JLOADR_JAR = "jloadr.jar";
   private static final String JLOADR_JAR_SHA1 = "jloadr.jar.sha1";
 
+  private static final String MIN_JAVA_VERSION = "1.9";
+  public static boolean CHECK_JAVA_VERSION = true;
+
   public static void main(String[] args) throws Throwable
   {
     if (args.length == 0)
@@ -31,6 +34,9 @@ public class Starter
     Throwable loadError = null;
     try
     {
+      if(CHECK_JAVA_VERSION)
+        _checkJavaVersion(MIN_JAVA_VERSION, System.getProperty("java.version"));
+
       URL url = BootstrapUtil.getMoved(new URL(args[0]));
       _loadNewVersion(url);
       args[0] = url.toExternalForm();
@@ -102,5 +108,25 @@ public class Starter
     {
       throw pE.getCause();
     }
+  }
+
+  /**
+   * This method checks if the used Java version is at least the minimum version. It only uses the first two instances
+   * of the version number to compare the versions
+   */
+
+  private static void _checkJavaVersion(String pMinimal, String pCurrent)
+  {
+    String[] minimalArray = pMinimal.split("\\.", 3);
+    String[] currentArray = pCurrent.split("\\.", 3);
+
+    int current = (Integer.parseInt(currentArray[0]) * 10) +
+        (currentArray.length < 2 ? 0 : Integer.parseInt(currentArray[1]));
+
+    int minimal = (Integer.parseInt(minimalArray[0]) * 10) +
+        (minimalArray.length < 2 ? 0 : Integer.parseInt(minimalArray[1]));
+
+    if(current < minimal)
+      throw new RuntimeException("Your Java is outdated, please use at least Java " + MIN_JAVA_VERSION);
   }
 }

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/Starter.java
@@ -29,10 +29,10 @@ public class Starter
     Throwable loadError = null;
     try
     {
-      if(!(VersionUtil.validateJavaVersion(System.getProperty("java.version"),
-          System.getProperty("min.java"))))
+      String minimalVersion = System.getProperty("min.java");
+      if(!(VersionUtil.validateJavaVersion(System.getProperty("java.version"), minimalVersion)))
         throw new RuntimeException("Your Java is outdated, please use at least Java " +
-            (System.getProperty("min.java") == null ? VersionUtil.getDefaultVersion() : System.getProperty("min.java")));
+            (minimalVersion == null ? VersionUtil.getDefaultVersion() : minimalVersion));
 
       URL url = BootstrapUtil.getMoved(new URL(args[0]));
       _loadNewVersion(url);

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/VersionUtil.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/VersionUtil.java
@@ -1,0 +1,81 @@
+package de.adito.jloadr.bootstrap;
+
+import java.io.File;
+
+/**
+ * @author m.schindlbeck, 12.03.19
+ */
+
+public class VersionUtil
+{
+  private final static String DEFAULT_MIN_JAVA_VERSION = "9";
+
+  /**
+   * The versions will be compared to determine that pCurrentVersion is at least pMinimalVersion. The check will be
+   * ignored if a 'jre' folder is included in the working directory.
+   */
+  public static boolean validateJavaVersion(String pCurrentVersion, String pMinimalVersion)
+  {
+    VersionUtil vu = new VersionUtil();
+    String minimalVersion = vu._validateVersionFormat(pMinimalVersion);
+    return vu._isExpectedJavaVersion(pCurrentVersion, minimalVersion);
+  }
+
+  /**
+   * Checks if the VM Java version is at least the minimum version. It only uses the first two instances
+   * of the version number to compare the version. If the folder 'jre' exists, the check will be ignored.
+   */
+
+  private boolean _isExpectedJavaVersion(String pCurrent, String pMinimal)
+  {
+    if(new File(System.getProperty("user.dir") + File.separator + "jre").exists())
+      return true;
+
+    String[] minimalArray = pMinimal.split("\\.", 3);
+    String[] currentArray = pCurrent.split("\\.", 3);
+
+    int current = (Integer.parseInt(currentArray[0]) * 10) +
+        (currentArray.length < 2 ? 0 : Integer.parseInt(currentArray[1]));
+
+    int minimal = (Integer.parseInt(minimalArray[0]) * 10) +
+        (minimalArray.length < 2 ? 0 : Integer.parseInt(minimalArray[1]));
+
+    if(current < minimal)
+      return false;
+
+    return true;
+  }
+
+  /**
+   * Validates the given version number. Numbers that start with '-' or a number between '2' and '8' will
+   * throw a RuntimeException. Versions like '1.8', '10', '10.2' etc are expected.
+   * @return a String with a valid version number
+   */
+  private String _validateVersionFormat(String pVersion)
+  {
+    if (pVersion == null)
+      return DEFAULT_MIN_JAVA_VERSION;
+
+    String[] versionArray = pVersion.split("\\.", 3);
+    int firstNumb;
+    try
+    {
+      firstNumb = Integer.parseInt(versionArray[0]);
+    }
+    catch(NumberFormatException pE)
+    {
+      throw new RuntimeException("The VM parameter 'min.java' must be a valid version number.");
+    }
+
+    if(firstNumb > 1 && firstNumb < 9 || firstNumb <= 0)
+      throw new RuntimeException("The VM parameter 'min.java' must be a valid version number.");
+
+    return pVersion;
+  }
+
+  public static String getDefaultVersion()
+  {
+    return DEFAULT_MIN_JAVA_VERSION;
+  }
+
+}

--- a/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/VersionUtil.java
+++ b/jloadr-bootstrap/src/main/java/de/adito/jloadr/bootstrap/VersionUtil.java
@@ -5,20 +5,26 @@ import java.io.File;
 /**
  * @author m.schindlbeck, 12.03.19
  */
-
-public class VersionUtil
+class VersionUtil
 {
-  private final static String DEFAULT_MIN_JAVA_VERSION = "9";
+  private static final String DEFAULT_MIN_JAVA_VERSION = "9";
+
+  /**
+   * Prevent instantiation
+   */
+  private VersionUtil()
+  {
+  }
 
   /**
    * The versions will be compared to determine that pCurrentVersion is at least pMinimalVersion. The check will be
    * ignored if a 'jre' folder is included in the working directory.
    */
-  public static boolean validateJavaVersion(String pCurrentVersion, String pMinimalVersion)
+  static boolean validateJavaVersion(String pCurrentVersion, String pMinimalVersion)
   {
-    VersionUtil vu = new VersionUtil();
-    String minimalVersion = vu._validateVersionFormat(pMinimalVersion);
-    return vu._isExpectedJavaVersion(pCurrentVersion, minimalVersion);
+    String minimalVersion = _validateVersionFormat(pMinimalVersion);
+    String currentVersion = _validateVersionFormat(pCurrentVersion);
+    return _isExpectedJavaVersion(currentVersion, minimalVersion);
   }
 
   /**
@@ -26,7 +32,7 @@ public class VersionUtil
    * of the version number to compare the version. If the folder 'jre' exists, the check will be ignored.
    */
 
-  private boolean _isExpectedJavaVersion(String pCurrent, String pMinimal)
+  private static boolean _isExpectedJavaVersion(String pCurrent, String pMinimal)
   {
     if(new File(System.getProperty("user.dir") + File.separator + "jre").exists())
       return true;
@@ -51,7 +57,7 @@ public class VersionUtil
    * throw a RuntimeException. Versions like '1.8', '10', '10.2' etc are expected.
    * @return a String with a valid version number
    */
-  private String _validateVersionFormat(String pVersion)
+  private static String _validateVersionFormat(String pVersion)
   {
     if (pVersion == null)
       return DEFAULT_MIN_JAVA_VERSION;
@@ -73,7 +79,7 @@ public class VersionUtil
     return pVersion;
   }
 
-  public static String getDefaultVersion()
+  static String getDefaultVersion()
   {
     return DEFAULT_MIN_JAVA_VERSION;
   }

--- a/jloadr-bootstrap/src/test/java/de/adito/jloadr/bootstrap/Test_VersionUtil.java
+++ b/jloadr-bootstrap/src/test/java/de/adito/jloadr/bootstrap/Test_VersionUtil.java
@@ -1,0 +1,70 @@
+package de.adito.jloadr.bootstrap;
+
+import org.junit.*;
+
+/**
+ * @author m.schindlbeck, 12.03.19
+ */
+public class Test_VersionUtil
+{
+  @Test
+  public void testCompareVersions()
+  {
+    Assert.assertFalse(VersionUtil.validateJavaVersion("1.0", "1.2"));
+    Assert.assertFalse(VersionUtil.validateJavaVersion("1.0", "9"));
+    Assert.assertFalse(VersionUtil.validateJavaVersion("1.4", "1.5"));
+    Assert.assertFalse(VersionUtil.validateJavaVersion("1.3", "1.6"));
+    Assert.assertFalse(VersionUtil.validateJavaVersion("9", "10"));
+    Assert.assertFalse(VersionUtil.validateJavaVersion("9", "11"));
+
+    Assert.assertTrue(VersionUtil.validateJavaVersion("1.2", "1.0"));
+    Assert.assertTrue(VersionUtil.validateJavaVersion("9", "1.0"));
+    Assert.assertTrue(VersionUtil.validateJavaVersion("1.5", "1.4"));
+    Assert.assertTrue(VersionUtil.validateJavaVersion("1.6", "1.3"));
+    Assert.assertTrue(VersionUtil.validateJavaVersion("10", "9"));
+    Assert.assertTrue(VersionUtil.validateJavaVersion("11", "9"));
+
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testFormatFirstNumber()
+  {
+    VersionUtil.validateJavaVersion("10", "5.1");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testFormatFirstNumberNegative()
+  {
+    VersionUtil.validateJavaVersion("10", "-5.1");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testFormatFirstNumberZero()
+  {
+    VersionUtil.validateJavaVersion("10", "0");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testFormatNoInteger()
+  {
+    VersionUtil.validateJavaVersion("10", "NoInt");
+  }
+
+  @Test
+  public void testFormatNull()
+  {
+    VersionUtil.validateJavaVersion("10", null);
+  }
+
+  @Test
+  public void testCorrectFormat()
+  {
+    VersionUtil.validateJavaVersion("10", "9");
+  }
+
+  @Test
+  public void testCorrectFormat2()
+  {
+    VersionUtil.validateJavaVersion("10", "1.8");
+  }
+}

--- a/jloadr/pom.xml
+++ b/jloadr/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>jloadr</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>1.0.8</version>
   <packaging>multi-release-jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
The java version will be compared to a minimal version (the user can define it with -Dmin.java="someVersion". Otherwise, the default '9' will be used). If the directory includes a 'jre' folder the comparison will be ignored.